### PR TITLE
Add versioning and metadata to project files for Wangkanai packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,10 +1,6 @@
 <Project>
 
    <PropertyGroup>
-      <VersionPrefix>1.0.0</VersionPrefix>
-      <Product>Wangkanai Domain</Product>
-      <PackageTags>wangkanai;domain;ddd;audit;entityframework;dotnet</PackageTags>
-
       <Company>Wangkanai</Company>
       <Authors>Sarin Na Wangkanai</Authors>
       <Copyright>Copyright © 2024 Sarin Na Wangkanai</Copyright>

--- a/src/Audit/Wangkanai.Audit.csproj
+++ b/src/Audit/Wangkanai.Audit.csproj
@@ -1,4 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+      <VersionPrefix>0.2.0</VersionPrefix>
+      <Product>Wangkanai Audit</Product>
+      <PackageTags>wangkanai;domain;ddd;audit;entityframework;dotnet</PackageTags>
+   </PropertyGroup>
    <ItemGroup>
       <PackageReference Include="Microsoft.EntityFrameworkCore"/>
       <PackageReference Include="Microsoft.EntityFrameworkCore.Relational"/>

--- a/src/Domain/Wangkanai.Domain.csproj
+++ b/src/Domain/Wangkanai.Domain.csproj
@@ -1,4 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
+   <PropertyGroup>
+      <VersionPrefix>5.0.0</VersionPrefix>
+      <Product>Wangkanai Domain</Product>
+      <PackageTags>wangkanai;domain;ddd;audit;entityframework;dotnet</PackageTags>
+   </PropertyGroup>
    <ItemGroup>
       <PackageReference Include="Microsoft.EntityFrameworkCore"/>
       <PackageReference Include="Microsoft.EntityFrameworkCore.Relational"/>

--- a/src/EntityFramework/Wangkanai.EntityFramework.csproj
+++ b/src/EntityFramework/Wangkanai.EntityFramework.csproj
@@ -1,5 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+   <PropertyGroup>
+      <VersionPrefix>3.7.0</VersionPrefix>
+      <Product>Wangkanai EntityFramework</Product>
+      <PackageTags>wangkanai;domain;ddd;audit;entityframework;dotnet</PackageTags>
+   </PropertyGroup>
+
    <ItemGroup>
       <FrameworkReference Include="Microsoft.AspNetCore.App"/>
    </ItemGroup>


### PR DESCRIPTION
This pull request refactors the way project metadata is managed by moving shared properties from the root `Directory.Build.props` into individual project files. This allows each project to have its own versioning and metadata, improving clarity and maintainability.

**Project metadata reorganization:**

* Removed `VersionPrefix`, `Product`, and `PackageTags` properties from the shared `Directory.Build.props` file.
* Added `VersionPrefix`, `Product`, and `PackageTags` properties directly to each project file:
  - `src/Audit/Wangkanai.Audit.csproj` now contains its own metadata.
  - `src/Domain/Wangkanai.Domain.csproj` now contains its own metadata.
  - `src/EntityFramework/Wangkanai.EntityFramework.csproj` now contains its own metadata.