### PR TITLE
Refactor IAggregateRoot interface for improved readability and format…

### DIFF
--- a/src/Audit/AuditableEntity.cs
+++ b/src/Audit/AuditableEntity.cs
@@ -10,15 +10,18 @@ public abstract class AuditableEntity<T>
 {
    /// <summary>Determines whether the auditable properties of the entity should be serialized.</summary>
    /// <remarks>This property acts as a central flag to control the serialization of all auditable timestamp properties, such as creation and modification dates. It can be overridden in derived classes to customize the serialization behavior based on specific requirements.</remarks>
-   public virtual bool ShouldSerializeAuditableProperties => true;
+   public virtual bool ShouldSerializeAuditableProperties
+      => true;
 
    /// <summary>Determines whether the Created date of the entity should be serialized.</summary>
    /// <returns>A boolean value indicating whether the Created date should be included in serialization.</returns>
-   public virtual bool ShouldSerializeCreatedDate() => ShouldSerializeAuditableProperties;
+   public virtual bool ShouldSerializeCreatedDate()
+      => ShouldSerializeAuditableProperties;
 
    /// <summary>Determines whether the Updated date of the entity should be serialized.</summary>
    /// <returns>A boolean value indicating whether the Updated date should be included in serialization.</returns>
-   public virtual bool ShouldSerializeUpdatedDate() => ShouldSerializeAuditableProperties;
+   public virtual bool ShouldSerializeUpdatedDate()
+      => ShouldSerializeAuditableProperties;
 
    #region IAuditable Members
 

--- a/src/Audit/SoftDeleteAuditableEntity.cs
+++ b/src/Audit/SoftDeleteAuditableEntity.cs
@@ -10,15 +10,18 @@ public abstract class SoftDeleteAuditableEntity<T>
 {
    /// <summary>Determines whether the soft delete properties of the entity should be serialized.</summary>
    /// <remarks>This property acts as a central flag to control the serialization of soft delete related properties. It can be overridden in derived classes to customize the serialization behavior based on specific requirements.</remarks>
-   public virtual bool ShouldSerializeSoftDeleteProperties => ShouldSerializeAuditableProperties;
+   public virtual bool ShouldSerializeSoftDeleteProperties
+      => ShouldSerializeAuditableProperties;
 
    /// <summary>Determines whether the IsDeleted flag of the entity should be serialized.</summary>
    /// <returns>A boolean value indicating whether the IsDeleted flag should be included in serialization.</returns>
-   public virtual bool ShouldSerializeIsDeleted() => ShouldSerializeSoftDeleteProperties;
+   public virtual bool ShouldSerializeIsDeleted()
+      => ShouldSerializeSoftDeleteProperties;
 
    /// <summary>Determines whether the Deleted date of the entity should be serialized.</summary>
    /// <returns>A boolean value indicating whether the Deleted date should be included in serialization.</returns>
-   public virtual bool ShouldSerializeDeleted() => ShouldSerializeSoftDeleteProperties;
+   public virtual bool ShouldSerializeDeleted()
+      => ShouldSerializeSoftDeleteProperties;
 
    #region ISoftDeletable Members
 

--- a/src/Audit/UserAuditableEntity.cs
+++ b/src/Audit/UserAuditableEntity.cs
@@ -11,8 +11,10 @@ public abstract class UserAuditableEntity<T>
    : AuditableEntity<T>, IUserAuditable
    where T : IComparable<T>, IEquatable<T>
 {
-   public virtual bool ShouldSerializeCreatedBy() => ShouldSerializeAuditableProperties;
-   public virtual bool ShouldSerializeUpdatedBy() => ShouldSerializeAuditableProperties;
+   public virtual bool ShouldSerializeCreatedBy()
+      => ShouldSerializeAuditableProperties;
+   public virtual bool ShouldSerializeUpdatedBy()
+      => ShouldSerializeAuditableProperties;
 
    #region IUserAuditable Members
 

--- a/src/Audit/UserSoftDeleteAuditableEntity.cs
+++ b/src/Audit/UserSoftDeleteAuditableEntity.cs
@@ -12,15 +12,18 @@ public abstract class UserSoftDeleteAuditableEntity<T>
 {
    /// <summary>Determines whether the CreatedBy property should be serialized.</summary>
    /// <returns>A boolean value indicating whether the CreatedBy property should be included in serialization.</returns>
-   public virtual bool ShouldSerializeCreatedBy() => ShouldSerializeAuditableProperties;
+   public virtual bool ShouldSerializeCreatedBy()
+      => ShouldSerializeAuditableProperties;
 
    /// <summary>Determines whether the UpdatedBy property should be serialized.</summary>
    /// <returns>A boolean value indicating whether the UpdatedBy property should be included in serialization.</returns>
-   public virtual bool ShouldSerializeUpdatedBy() => ShouldSerializeAuditableProperties;
+   public virtual bool ShouldSerializeUpdatedBy()
+      => ShouldSerializeAuditableProperties;
 
    /// <summary>Determines whether the DeletedBy property should be serialized.</summary>
    /// <returns>A boolean value indicating whether the DeletedBy property should be included in serialization.</returns>
-   public virtual bool ShouldSerializeDeletedBy() => ShouldSerializeSoftDeleteProperties;
+   public virtual bool ShouldSerializeDeletedBy()
+      => ShouldSerializeSoftDeleteProperties;
 
    #region IUserAuditable Members
 

--- a/src/Domain/Interfaces/IAggregateRoot.cs
+++ b/src/Domain/Interfaces/IAggregateRoot.cs
@@ -7,10 +7,13 @@ namespace Wangkanai.Domain;
 /// An aggregate root is the primary entry point to interact with aggregates,
 /// ensuring all operations on an aggregate are controlled and consistent.
 /// </summary>
-public interface IAggregateRoot : IAggregateRoot<int>, IKeyIntEntity;
+public interface IAggregateRoot
+   : IAggregateRoot<int>, IKeyIntEntity;
 
 /// <summary>
 /// Defines a contract for aggregate roots in a domain-driven design context with a primary key of type int.
 /// Ensures all operations on the aggregate are controlled and consistent through the aggregate root.
 /// </summary>
-public interface IAggregateRoot<T> : IEntity<T> where T : IComparable<T>, IEquatable<T>;
+public interface IAggregateRoot<T>
+   : IEntity<T>
+   where T : IComparable<T>, IEquatable<T>;

--- a/src/Domain/Interfaces/IValueObject.cs
+++ b/src/Domain/Interfaces/IValueObject.cs
@@ -13,4 +13,5 @@ public interface IValueObject;
 /// Value objects are inherently immutable, and their equality is determined based on their
 /// constituent properties rather than a unique identifier.
 /// </summary>
-public interface IValueObject<T> where T : class;
+public interface IValueObject<T>
+   where T : class;


### PR DESCRIPTION
This pull request consists of minor formatting updates across several audit and domain interface classes. The main change is the consistent application of multiline formatting for method signatures and interface declarations to improve readability and maintainability. No functional or behavioral changes were made.

Formatting improvements for readability:

* Updated method signatures in `AuditableEntity<T>`, `SoftDeleteAuditableEntity<T>`, `UserAuditableEntity<T>`, and `UserSoftDeleteAuditableEntity<T>` to use multiline formatting for all `ShouldSerialize*` methods, making them easier to read and override. [[1]](diffhunk://#diff-6f4b7a4d73259038f37a04220fd715e7e714b273a62fb30e05d4ef35d52fc1d3L13-R24) [[2]](diffhunk://#diff-e810d44fb9c3d9afc92ec0858002e0dab2b3dcf764e4254b85aaa50b53480f7aL13-R24) [[3]](diffhunk://#diff-f1b7b57878354810bbc1df01c9d4bd378e4d862c81cfdb379851a18913e0d5b3L14-R17) [[4]](diffhunk://#diff-19fcc972890483c62d05dd239c33b64fc03a661910c0e5fa123cac6d0c55c126L15-R26)
* Reformatted interface declarations in `IAggregateRoot`, `IAggregateRoot<T>`, and `IValueObject<T>` to multiline style, improving clarity and consistency in the domain interfaces. [[1]](diffhunk://#diff-c9e7848c902edebc452375d633dbae40995f99c328458daea04b7ec6454fac15L10-R19) [[2]](diffhunk://#diff-bd681c0257efcdea63646a6849d46d93ffd6b2fe2709a6d19e763c4f67c90c4aL16-R17)