### PR TITLE
Sign

### DIFF
--- a/sign.ps1
+++ b/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$publish=$false,
+    [bool]$publish=$true,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )

--- a/sign.ps1
+++ b/sign.ps1
@@ -19,14 +19,14 @@ new-item -Path artifacts -ItemType Directory -Force | out-null
 new-item -Path signed    -ItemType Directory -Force | out-null
 
 dotnet --version
-dotnet clean   .\src\ -c Release -tl
-dotnet restore .\src\
-dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+dotnet clean   -c Release -tl
+dotnet restore
+dotnet build   -c Release -tl
+Get-ChildItem  -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
     signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 
-dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
+dotnet pack -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed


### PR DESCRIPTION
This pull request updates the `sign.ps1` PowerShell script to streamline the build and signing process and change the default behavior for publishing. The most significant changes involve simplifying `dotnet` commands and modifying the default value for the `publish` parameter.

Build and publish process improvements:

* Changed the default value of the `publish` parameter from `false` to `true`, so publishing is enabled by default.
* Simplified `dotnet` commands by removing explicit references to the `src` directory, allowing them to run in the current context. This affects `clean`, `restore`, `build`, and `pack` steps.
* Updated the `Get-ChildItem` command to search for DLLs recursively without specifying the `src` directory, making the script more flexible.