### PR TITLE
Move audit DbContext classes to Audit module

### DIFF
--- a/src/Audit/AuditDbContext.cs
+++ b/src/Audit/AuditDbContext.cs
@@ -2,7 +2,7 @@
 
 using Microsoft.EntityFrameworkCore;
 
-namespace Wangkanai.EntityFramework;
+namespace Wangkanai.Audit;
 
 /// <summary>
 /// Represents an abstract database context that supports auditing capabilities.

--- a/src/Audit/IAuditDbContext.cs
+++ b/src/Audit/IAuditDbContext.cs
@@ -2,7 +2,7 @@
 
 using Microsoft.EntityFrameworkCore;
 
-namespace Wangkanai.EntityFramework;
+namespace Wangkanai.Audit;
 
 /// <summary>
 /// Defines the contract for an audit-aware database context.


### PR DESCRIPTION
Relocates IAuditDbContext and AuditDbContext from the EntityFramework module to the Audit module for better architectural alignment.

Changes:
- Move src/EntityFramework/IAuditDbContext.cs → src/Audit/IAuditDbContext.cs
- Move src/EntityFramework/AuditDbContext.cs → src/Audit/AuditDbContext.cs
- Update namespace from Wangkanai.EntityFramework to Wangkanai.Audit

These classes are audit-specific abstractions that belong with other audit domain types rather than general EF utilities.