### PR TITLE
Add extension methods for auditable entity configurations

### DIFF
--- a/src/Audit/Extensions/AuditContextExtensions.cs
+++ b/src/Audit/Extensions/AuditContextExtensions.cs
@@ -19,4 +19,25 @@ public static class AuditContextExtensions
       where TUserType : IdentityUser<TUserKey>
       where TUserKey : IEquatable<TUserKey>, IComparable<TUserKey>
       => builder.ApplyConfiguration<Audit<TKey, TUserType, TUserKey>>(new AuditConfiguration<TKey, TUserType, TUserKey>());
+
+   /// <summary>Applies user auditable entity configuration to the Entity Framework model.</summary>
+   /// <typeparam name="TKey">The type of the primary key for the auditable entity.</typeparam>
+   /// <param name="builder">The Entity Framework <see cref="ModelBuilder"/> used to configure entity mappings.</param>
+   public static void ApplyUserAuditConfiguration<TKey>(this ModelBuilder builder)
+      where TKey : IEquatable<TKey>, IComparable<TKey>
+      => builder.ApplyConfiguration(new UserAuditConfiguration<TKey>());
+
+   /// <summary>Applies soft delete auditable entity configuration to the Entity Framework model.</summary>
+   /// <typeparam name="TKey">The type of the primary key for the auditable entity.</typeparam>
+   /// <param name="builder">The Entity Framework <see cref="ModelBuilder"/> used to configure entity mappings.</param>
+   public static void ApplySoftDeleteAuditConfiguration<TKey>(this ModelBuilder builder)
+      where TKey : IEquatable<TKey>, IComparable<TKey>
+      => builder.ApplyConfiguration(new SoftDeleteAuditConfiguration<TKey>());
+
+   /// <summary>Applies soft delete user auditable entity configuration to the Entity Framework model.</summary>
+   /// <typeparam name="TKey">The type of the primary key for the auditable entity.</typeparam>
+   /// <param name="builder">The Entity Framework <see cref="ModelBuilder"/> used to configure entity mappings.</param>
+   public static void ApplySoftDeleteUserAuditConfiguration<TKey>(this ModelBuilder builder)
+      where TKey : IEquatable<TKey>, IComparable<TKey>
+      => builder.ApplyConfiguration(new SoftDeleteUserAuditConfiguration<TKey>());
 }

--- a/src/Audit/Extensions/AuditContextExtensions.cs
+++ b/src/Audit/Extensions/AuditContextExtensions.cs
@@ -40,4 +40,19 @@ public static class AuditContextExtensions
    public static void ApplySoftDeleteUserAuditConfiguration<TKey>(this ModelBuilder builder)
       where TKey : IEquatable<TKey>, IComparable<TKey>
       => builder.ApplyConfiguration(new SoftDeleteUserAuditConfiguration<TKey>());
+
+   /// <summary>Applies all auditable entity configurations to the Entity Framework model.</summary>
+   /// <typeparam name="TKey">The type of the primary key for the auditable entities.</typeparam>
+   /// <param name="builder">The Entity Framework <see cref="ModelBuilder"/> used to configure entity mappings.</param>
+   /// <remarks>
+   /// This method applies configurations for UserAuditableEntity, SoftDeleteAuditableEntity, 
+   /// and UserSoftDeleteAuditableEntity in a single call for convenience.
+   /// </remarks>
+   public static void ApplyAuditableEntityConfigurations<TKey>(this ModelBuilder builder)
+      where TKey : IEquatable<TKey>, IComparable<TKey>
+   {
+      builder.ApplyUserAuditConfiguration<TKey>();
+      builder.ApplySoftDeleteAuditConfiguration<TKey>();
+      builder.ApplySoftDeleteUserAuditConfiguration<TKey>();
+   }
 }


### PR DESCRIPTION
## Summary
• Add `ApplyUserAuditConfiguration<TKey>()` extension method
• Add `ApplySoftDeleteAuditConfiguration<TKey>()` extension method  
• Add `ApplySoftDeleteUserAuditConfiguration<TKey>()` extension method
• Maintain consistent API pattern with existing `ApplyAuditConfiguration()` method

## Test plan
- [x] Verify extension methods follow existing naming conventions
- [x] Confirm methods properly apply their respective configurations
- [ ] Integration test with DbContext configuration
- [ ] Verify all entity configurations work together