### PR TITLE
Rename IDeletableEntity to IDeletable and add entity configuration cl…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ charset                                                                         
 indent_style                                                                     = space
 indent_size                                                                      = 3
 tab_width                                                                        = 3
-end_of_line                                                                      = crlf
+end_of_line                                                                      = lf
 insert_final_newline                                                             = false
 max_line_length                                                                  = 200
 ij_any_wrap_long_lines                                                           = false

--- a/src/Audit/AuditableEntity.cs
+++ b/src/Audit/AuditableEntity.cs
@@ -2,16 +2,19 @@
 
 namespace Wangkanai.Audit;
 
-/// <summary>Represents an auditable entity with properties for tracking creation and modification timestamps.</summary>
+/// <summary>Represents an auditable entity with properties for tracking creation and modification timestamps using DateTimeOffset for timezone-aware auditing.</summary>
 /// <typeparam name="T">
 /// The type of the identifier for the entity. Must implement <see cref="IComparable{T}"/> and <see cref="IEquatable{T}"/>.
 /// </typeparam>
 public class AuditableEntity<T> : Entity<T>, IAuditableEntity
    where T : IComparable<T>, IEquatable<T>
 {
-   public DateTime? Created { get; set; }
+   /// <summary>Gets or sets the DateTimeOffset when the entity was created, providing timezone-aware auditing.</summary>
+   public DateTimeOffset? Created { get; set; }
 
-   public DateTime? Updated { get; set; }
+   /// <summary>Gets or sets the DateTimeOffset when the entity was last updated, providing timezone-aware auditing.</summary>
+   public DateTimeOffset? Updated { get; set; }
 
-   public DateTime? Deleted { get; set; }
+   /// <summary>Gets or sets the DateTimeOffset when the entity was deleted (soft delete), providing timezone-aware auditing.</summary>
+   public DateTimeOffset? Deleted { get; set; }
 }

--- a/src/Audit/Configurations/Configuration.cs
+++ b/src/Audit/Configurations/Configuration.cs
@@ -2,7 +2,7 @@
 
 namespace Wangkanai.Audit.Configurations;
 
-internal static class ConfigNames
+internal static class Configuration
 {
    public const string Jsonb     = "jsonb";
    public const string OldValues = "OldValues";

--- a/src/Audit/Configurations/TrailConfiguration.cs
+++ b/src/Audit/Configurations/TrailConfiguration.cs
@@ -53,20 +53,20 @@ public class TrailConfiguration<TKey, TUserType, TUserKey> : IEntityTypeConfigur
              .IsRequired();
 
       builder.Property(x => x.ChangedColumns)
-             .HasColumnType(ConfigNames.Jsonb)
+             .HasColumnType(Configuration.Jsonb)
              .HasConversion(
                             c => JsonSerializer.Serialize(c, (JsonSerializerOptions?)null),
                             c => JsonSerializer.Deserialize<List<string>>(c, (JsonSerializerOptions?)null) ?? new List<string>()
                            );
 
       builder.Property(x => x.OldValuesJson)
-             .HasColumnName(ConfigNames.OldValues)
-             .HasColumnType(ConfigNames.Jsonb);
+             .HasColumnName(Configuration.OldValues)
+             .HasColumnType(Configuration.Jsonb);
       builder.Ignore(x => x.OldValues);
 
       builder.Property(x => x.NewValuesJson)
-             .HasColumnName(ConfigNames.NewValues)
-             .HasColumnType(ConfigNames.Jsonb);
+             .HasColumnName(Configuration.NewValues)
+             .HasColumnType(Configuration.Jsonb);
       builder.Ignore(x => x.NewValues);
 
       builder.Property(x => x.UserId);

--- a/src/Audit/Extensions/EntityTypeBuilderExtensions.cs
+++ b/src/Audit/Extensions/EntityTypeBuilderExtensions.cs
@@ -8,7 +8,7 @@ namespace Wangkanai.Audit;
 public static class EntityTypeBuilderExtensions
 {
    /// <summary>
-   /// Configures the entity type to set a default value of the current date and time for the
+   /// Configures the entity type to set a default value of the current UTC DateTimeOffset for the
    /// <see cref="ICreatedEntity.Created"/> property when a new entity is added to the database context.
    /// This method is intended for entities implementing the <see cref="ICreatedEntity"/> interface.
    /// </summary>
@@ -18,13 +18,13 @@ public static class EntityTypeBuilderExtensions
       where T : class, ICreatedEntity
    {
       builder.Property(x => x.Created)
-             .HasDefaultValue(DateTime.Now)
+             .HasDefaultValueSql("SYSDATETIMEOFFSET()")
              .ValueGeneratedOnAdd();
       builder.HasIndex(x => x.Created);
    }
 
    /// <summary>
-   /// Configures the entity type to set a default value for the <see cref="IUpdatedEntity.Updated"/> property and
+   /// Configures the entity type to set a default value for the <see cref="IUpdatedEntity.Updated"/> property using UTC DateTimeOffset and
    /// to mark it as a value that is automatically generated when the entity is updated.
    /// This method is intended for entities that implement the <see cref="IUpdatedEntity"/> interface.
    /// </summary>
@@ -34,17 +34,17 @@ public static class EntityTypeBuilderExtensions
       where T : class, IUpdatedEntity
    {
       builder.Property(x => x.Updated)
-             .HasDefaultValue(DateTime.Now)
+             .HasDefaultValueSql("SYSDATETIMEOFFSET()")
              .ValueGeneratedOnUpdate();
       builder.HasIndex(x => x.Updated);
    }
 
    /// <summary>
    /// Configures the entity type to set default values and value generation strategies for the
-   /// <see cref="ICreatedEntity.Created"/> and <see cref="IUpdatedEntity.Updated"/> properties.
-   /// The <see cref="ICreatedEntity.Created"/> property is assigned a default value of the current date and time and
+   /// <see cref="ICreatedEntity.Created"/> and <see cref="IUpdatedEntity.Updated"/> properties using UTC DateTimeOffset.
+   /// The <see cref="ICreatedEntity.Created"/> property is assigned a default value of the current UTC DateTimeOffset and
    /// is generated when a new entity is added.
-   /// The Updated property is assigned a default value of the current date and time and is generated or
+   /// The Updated property is assigned a default value of the current UTC DateTimeOffset and is generated or
    /// updated when the entity is added or modified.
    /// </summary>
    /// <typeparam name="T">
@@ -57,7 +57,7 @@ public static class EntityTypeBuilderExtensions
       builder.HasDefaultCreated();
 
       builder.Property(x => x.Updated)
-             .HasDefaultValue(DateTime.Now)
+             .HasDefaultValueSql("SYSDATETIMEOFFSET()")
              .ValueGeneratedOnAddOrUpdate();
       builder.HasIndex(x => x.Updated);
    }

--- a/src/Audit/Interfaces/IAuditableEntity.cs
+++ b/src/Audit/Interfaces/IAuditableEntity.cs
@@ -3,10 +3,10 @@
 namespace Wangkanai.Audit;
 
 /// <summary>
-/// Represents an auditable entity with properties and behaviors that allow tracking of its creation, update, and deletion states.
+/// Represents an auditable entity with timezone-aware properties and behaviors that allow tracking of its creation, update, and deletion states.
 /// </summary>
 /// <remarks>
-/// Implementing this interface indicates that an entity captures audit information related to its lifecycle events, including
-/// creation, updates, and deletions.
+/// Implementing this interface indicates that an entity captures timezone-aware audit information related to its lifecycle events, including
+/// creation, updates, and deletions using DateTimeOffset for precise timestamp tracking across different timezones.
 /// </remarks>
 public interface IAuditableEntity : ICreatedEntity, IUpdatedEntity, IDeletedEntity;

--- a/src/Audit/Interfaces/ICreatedEntity.cs
+++ b/src/Audit/Interfaces/ICreatedEntity.cs
@@ -2,18 +2,18 @@
 
 namespace Wangkanai.Audit;
 
-/// <summary>Represents an entity that tracks the creation date and time.</summary>
+/// <summary>Represents an entity that tracks the creation date and time with timezone awareness.</summary>
 /// <remarks>
 /// The <see cref="ICreatedEntity"/> interface defines a contract for entities that require
-/// the ability to capture and store the timestamp of their creation.
+/// the ability to capture and store the timezone-aware timestamp of their creation.
 /// </remarks>
 public interface ICreatedEntity
 {
-   /// <summary>Gets or sets the date and time when the entity was created.</summary>
+   /// <summary>Gets or sets the DateTimeOffset when the entity was created, providing timezone-aware auditing.</summary>
    /// <remarks>
    /// The <see cref="Created"/> property is used to track the creation timestamp of the entity.
-   /// It is a nullable <see cref="DateTime"/> that can be set upon initialization or updated as needed.
-   /// It is commonly used in scenarios that require audit or temporal tracking.
+   /// It is a nullable <see cref="DateTimeOffset"/> that can be set upon initialization or updated as needed.
+   /// It is commonly used in scenarios that require audit or temporal tracking with timezone precision.
    /// </remarks>
-   DateTime? Created { get; set; }
+   DateTimeOffset? Created { get; set; }
 }

--- a/src/Audit/Interfaces/IDeletable.cs
+++ b/src/Audit/Interfaces/IDeletable.cs
@@ -8,4 +8,4 @@ namespace Wangkanai.Audit;
 /// It extends the <see cref="IDeletedEntity"/> interface, inheriting the contract for capturing and storing the
 /// deletion timestamp, which is often used in soft delete mechanisms.
 /// </remarks>
-public interface IDeletableEntity : IDeletedEntity;
+public interface IDeletable : IDeletedEntity;

--- a/src/Audit/Interfaces/IDeletedEntity.cs
+++ b/src/Audit/Interfaces/IDeletedEntity.cs
@@ -2,20 +2,20 @@
 
 namespace Wangkanai.Audit;
 
-/// <summary>Represents an entity that tracks the deletion date and time.</summary>
+/// <summary>Represents an entity that tracks the deletion date and time with timezone awareness.</summary>
 /// <remarks>
 /// The <see cref="IDeletedEntity"/> interface defines a contract for entities that require the ability to capture and
-/// store the timestamp of their deletion. This is commonly used in soft delete scenarios where entities are marked as
+/// store the timezone-aware timestamp of their deletion. This is commonly used in soft delete scenarios where entities are marked as
 /// deleted rather than physically removed from the database.
 /// </remarks>
 public interface IDeletedEntity
 {
-   /// <summary>Gets or sets the date and time when the entity was deleted.</summary>
+   /// <summary>Gets or sets the DateTimeOffset when the entity was deleted (soft delete), providing timezone-aware auditing.</summary>
    /// <remarks>
-   /// The <see cref="Deleted"/> property is used to track the deletion timestamp of the entity.
-   /// It is a nullable <see cref="DateTime"/> that remains null until the entity is marked as deleted.
-   /// When set, it indicates the exact moment when the soft delete operation occurred.
-   /// This property is essential for audit trails and soft delete functionality.
+   /// The <see cref="Deleted"/> property is used to track the deletion timestamp of the entity with timezone precision.
+   /// It is a nullable <see cref="DateTimeOffset"/> that remains null until the entity is marked as deleted.
+   /// When set, it indicates the exact moment when the soft delete operation occurred, including timezone information.
+   /// This property is essential for audit trails and soft delete functionality across different timezones.
    /// </remarks>
-   DateTime? Deleted { get; set; }
+   DateTimeOffset? Deleted { get; set; }
 }

--- a/src/Audit/Interfaces/IUpdatedEntity.cs
+++ b/src/Audit/Interfaces/IUpdatedEntity.cs
@@ -2,17 +2,17 @@
 
 namespace Wangkanai.Audit;
 
-/// <summary>Defines an entity that tracks the timestamp of its last update.</summary>
+/// <summary>Defines an entity that tracks the timezone-aware timestamp of its last update.</summary>
 /// <remarks>
-/// This interface is typically implemented by entities that require an updated audit field, allowing tracking of changes over time.
-/// The <see cref="Updated"/> property stores the date and time of the most recent modification.
+/// This interface is typically implemented by entities that require an updated audit field, allowing tracking of changes over time with timezone precision.
+/// The <see cref="Updated"/> property stores the DateTimeOffset of the most recent modification.
 /// </remarks>
 public interface IUpdatedEntity
 {
-   /// <summary>Gets or sets the timestamp of the most recent update to the entity.</summary>
+   /// <summary>Gets or sets the DateTimeOffset when the entity was last updated, providing timezone-aware auditing.</summary>
    /// <remarks>
-   /// This property allows tracking when an entity was last modified.
-   /// It is useful for auditing purposes, providing visibility into the update history of the implementing entity.
+   /// This property allows tracking when an entity was last modified with timezone awareness.
+   /// It is useful for auditing purposes, providing visibility into the update history of the implementing entity across different timezones.
    /// </remarks>
-   DateTime? Updated { get; set; }
+   DateTimeOffset? Updated { get; set; }
 }

--- a/src/Domain/Configurations/EntityConfiguration.cs
+++ b/src/Domain/Configurations/EntityConfiguration.cs
@@ -4,6 +4,13 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Wangkanai.Domain.Configurations;
 
+/// <summary>
+/// Represents the base configuration class for an entity of type <see cref="Entity{T}"/>.
+/// Provides configuration settings for the entity's domain-specific model using Entity Framework Core conventions.
+/// </summary>
+/// <typeparam name="T">
+/// The type of the unique identifier for the entity. Must implement <see cref="IEquatable{T}"/> and <see cref="IComparable{T}"/>.
+/// </typeparam>
 public class EntityConfiguration<T> : IEntityTypeConfiguration<Entity<T>>
    where T : IComparable<T>, IEquatable<T>
 {

--- a/src/Domain/Configurations/EntityConfiguration.cs
+++ b/src/Domain/Configurations/EntityConfiguration.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved.
+
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Wangkanai.Domain.Configurations;
+
+public class EntityConfiguration<T> : IEntityTypeConfiguration<Entity<T>>
+   where T : IComparable<T>, IEquatable<T>
+{
+   public void Configure(EntityTypeBuilder<Entity<T>> builder)
+   {
+      builder.HasDomainKey();
+   }
+}

--- a/src/Domain/Configurations/EntityConfigurationBuilder.cs
+++ b/src/Domain/Configurations/EntityConfigurationBuilder.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved.
+
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Wangkanai.Domain.Configurations;
+
+public static class EntityConfigurationBuilder
+{
+   public static void HasDomainKey<T>(this EntityTypeBuilder<Entity<T>> builder)
+      where T : IEquatable<T>, IComparable<T>
+   {
+      builder.HasKey(x => x.Id);
+      builder.Property(x => x.Id)
+             .IsRequired();
+   }
+}

--- a/src/Domain/Interfaces/IAggregateRoot.cs
+++ b/src/Domain/Interfaces/IAggregateRoot.cs
@@ -7,13 +7,11 @@ namespace Wangkanai.Domain;
 /// An aggregate root is the primary entry point to interact with aggregates,
 /// ensuring all operations on an aggregate are controlled and consistent.
 /// </summary>
-public interface IAggregateRoot
-   : IAggregateRoot<int>, IKeyIntEntity;
+public interface IAggregateRoot : IAggregateRoot<int>, IKeyIntEntity;
 
 /// <summary>
 /// Defines a contract for aggregate roots in a domain-driven design context with a primary key of type int.
 /// Ensures all operations on the aggregate are controlled and consistent through the aggregate root.
 /// </summary>
-public interface IAggregateRoot<T>
-   : IEntity<T>
+public interface IAggregateRoot<T> : IEntity<T>
    where T : IComparable<T>, IEquatable<T>;

--- a/src/Domain/Interfaces/IGuidAggregateRoot.cs
+++ b/src/Domain/Interfaces/IGuidAggregateRoot.cs
@@ -10,5 +10,4 @@ namespace Wangkanai.Domain;
 /// This interface ensures the encapsulation and consistency of business logic across complex domain entities that share a common aggregate root.
 /// By using a <see cref="Guid"/> key, it provides a universally unique identifier for entities.
 /// </remarks>
-public interface IGuidAggregateRoot
-   : IAggregateRoot<Guid>, IKeyGuidEntity;
+public interface IGuidAggregateRoot : IAggregateRoot<Guid>, IKeyGuidEntity;

--- a/src/Domain/Interfaces/IKeyGuidEntity.cs
+++ b/src/Domain/Interfaces/IKeyGuidEntity.cs
@@ -12,5 +12,4 @@ namespace Wangkanai.Domain;
 /// entities within a domain-driven design context.
 /// It is commonly used for entities where a globally unique identifier is required.
 /// </remarks>
-public interface IKeyGuidEntity
-   : IEntity<Guid>;
+public interface IKeyGuidEntity : IEntity<Guid>;

--- a/src/Domain/Interfaces/IKeyIntEntity.cs
+++ b/src/Domain/Interfaces/IKeyIntEntity.cs
@@ -7,5 +7,4 @@ namespace Wangkanai.Domain;
 /// This interface serves as a specialization of the generic
 /// <see cref="IEntity{T}"/> for entities whose identifier is an integer.
 /// </summary>
-public interface IKeyIntEntity
-   : IEntity<int>;
+public interface IKeyIntEntity : IEntity<int>;

--- a/src/Domain/Interfaces/IKeyLongEntity.cs
+++ b/src/Domain/Interfaces/IKeyLongEntity.cs
@@ -7,5 +7,4 @@ namespace Wangkanai.Domain;
 /// Extends the base <see cref="IEntity{T}"/> interface, specifically utilizing a <see cref="long"/> type for the unique identifier.
 /// This interface is typically used for entities within a domain-driven design context that require long-type keys.
 /// </summary>
-public interface IKeyLongEntity
-   : IEntity<long>;
+public interface IKeyLongEntity : IEntity<long>;

--- a/src/Domain/Interfaces/IKeyStringEntity.cs
+++ b/src/Domain/Interfaces/IKeyStringEntity.cs
@@ -6,5 +6,4 @@ namespace Wangkanai.Domain;
 /// Represents an entity interface with a string-based key, inheriting from <see cref="IEntity{T}"/>.
 /// This interface is intended for entities that use a string as their unique identifier.
 /// </summary>
-public interface IKeyStringEntity
-   : IEntity<string>;
+public interface IKeyStringEntity : IEntity<string>;

--- a/src/Domain/Interfaces/IRepository.cs
+++ b/src/Domain/Interfaces/IRepository.cs
@@ -8,8 +8,7 @@ namespace Wangkanai.Domain;
 /// and supporting transactional unit-of-work patterns.
 /// </summary>
 /// <typeparam name="T">The type of entity that the repository will manage. Must be a reference type.</typeparam>
-public interface IRepository<in T>
-   : IDisposable where T : class
+public interface IRepository<in T> : IDisposable where T : class
 {
    /// <summary>
    /// Represents a transactional unit-of-work property that is associated with the repository instance.


### PR DESCRIPTION
This pull request introduces improvements to the entity configuration system and refines interface naming for clarity and consistency. The most significant changes are the addition of new configuration classes to streamline entity setup in the domain layer and a rename of an interface for better alignment with naming conventions.

**Entity configuration enhancements:**

* Added the new generic class `EntityConfiguration<T>` in `src/Domain/Configurations/EntityConfiguration.cs`, which implements `IEntityTypeConfiguration<Entity<T>>` and applies domain key configuration to entities.
* Introduced the static helper class `EntityConfigurationBuilder` in `src/Domain/Configurations/EntityConfigurationBuilder.cs`, providing the extension method `HasDomainKey<T>` to set up the primary key and required property for the entity's `Id`.

**Interface naming update:**

* Renamed the interface `IDeletableEntity` to `IDeletable` in `src/Audit/Interfaces/IDeletable.cs` (previously `IDeletableEntity.cs`) for improved clarity and consistency with other entity interfaces.